### PR TITLE
fix: add CI-compatible Chrome flags for Puppeteer

### DIFF
--- a/src/scrape/getUserInfo.ts
+++ b/src/scrape/getUserInfo.ts
@@ -10,7 +10,19 @@ export async function getKaggleuserProfile(
   userName: string
 ): Promise<KaggleProfile> {
   const url = `https://www.kaggle.com/${userName}`;
-  const browser = await puppeteer.launch({ headless: true });
+  const browser = await puppeteer.launch({ 
+    headless: true,
+    args: process.env.CI ? [
+      '--no-sandbox',
+      '--disable-setuid-sandbox',
+      '--disable-dev-shm-usage',
+      '--disable-accelerated-2d-canvas',
+      '--no-first-run',
+      '--no-zygote',
+      '--single-process',
+      '--disable-gpu'
+    ] : []
+  });
   const page: Page = await browser.newPage();
   await page.goto(url, { waitUntil: "networkidle2" });
   await new Promise((resolve) => setTimeout(resolve, 10000));


### PR DESCRIPTION
Fixes Puppeteer Chrome sandbox errors in GitHub Actions environment.

### Changes:
- Added CI-compatible Chrome flags for Puppeteer in `src/scrape/getUserInfo.ts`
- Used `process.env.CI` to conditionally apply `--no-sandbox` and related flags
- Maintains local development compatibility

Closes #6

Generated with [Claude Code](https://claude.ai/code)